### PR TITLE
Add tests and CI for DistributedPromiseWrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,0 +1,195 @@
+import { DistributedPromiseWrapper } from './index'
+import { RedisClient } from 'redis'
+import { EventEmitter } from 'events'
+
+jest.mock('redis', () => ({
+  createClient: jest.fn().mockReturnValue({
+    get: jest.fn(),
+    set: jest.fn(),
+    psetex: jest.fn(),
+    publish: jest.fn(),
+    subscribe: jest.fn(),
+    unsubscribe: jest.fn(),
+    duplicate: jest.fn().mockReturnThis(),
+    on: jest.fn()
+  })
+}))
+
+describe('DistributedPromiseWrapper', () => {
+  let redisClient: RedisClient
+  let wrapper: DistributedPromiseWrapper
+
+  beforeEach(() => {
+    redisClient = new RedisClient({})
+    wrapper = new DistributedPromiseWrapper({ redis: redisClient })
+  })
+
+  describe('wrap', () => {
+    it('should handle cache hits', async () => {
+      const work = jest.fn().mockResolvedValue('result')
+      const key = 'testKey'
+      const args = ['arg1', 'arg2']
+
+      redisClient.get = jest.fn((_, cb) => cb(null, JSON.stringify('cachedResult')))
+
+      const wrappedWork = wrapper.wrap(work, key)
+      const result = await wrappedWork(...args)
+
+      expect(result).toBe('cachedResult')
+      expect(work).not.toHaveBeenCalled()
+    })
+
+    it('should handle cache misses and acquire lock', async () => {
+      const work = jest.fn().mockResolvedValue('result')
+      const key = 'testKey'
+      const args = ['arg1', 'arg2']
+
+      redisClient.get = jest.fn((_, cb) => cb(null, null))
+      redisClient.set = jest.fn((_, __, ___, ____, cb) => cb(null, 'OK'))
+      redisClient.psetex = jest.fn((_, __, ___, cb) => cb(null))
+      redisClient.publish = jest.fn((_, __, cb) => cb(null))
+
+      const wrappedWork = wrapper.wrap(work, key)
+      const result = await wrappedWork(...args)
+
+      expect(result).toBe('result')
+      expect(work).toHaveBeenCalledWith(...args)
+    })
+
+    it('should handle cache misses and wait for another process', async () => {
+      const work = jest.fn().mockResolvedValue('result')
+      const key = 'testKey'
+      const args = ['arg1', 'arg2']
+
+      redisClient.get = jest.fn((_, cb) => cb(null, null))
+      redisClient.set = jest.fn((_, __, ___, ____, cb) => cb(null, null))
+      redisClient.subscribe = jest.fn((_, cb) => cb(null))
+      redisClient.on = jest.fn((event, cb) => {
+        if (event === 'message') {
+          cb(wrapper['_getNotifKey'](key), JSON.stringify('result'))
+        }
+      })
+
+      const wrappedWork = wrapper.wrap(work, key)
+      const result = await wrappedWork(...args)
+
+      expect(result).toBe('result')
+      expect(work).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('_get', () => {
+    it('should get data from Redis', async () => {
+      const key = 'testKey'
+      const data = 'testData'
+
+      redisClient.get = jest.fn((_, cb) => cb(null, JSON.stringify(data)))
+
+      const result = await wrapper['_get'](key)
+
+      expect(result).toBe(data)
+    })
+  })
+
+  describe('_pushData', () => {
+    it('should push data to Redis and publish notification', async () => {
+      const key = 'testKey'
+      const data = 'testData'
+
+      redisClient.psetex = jest.fn((_, __, ___, cb) => cb(null))
+      redisClient.publish = jest.fn((_, __, cb) => cb(null))
+
+      const result = await wrapper['_pushData'](key, data)
+
+      expect(result).toBe(true)
+    })
+  })
+
+  describe('_subscribe', () => {
+    it('should subscribe to a Redis channel', async () => {
+      const key = 'testKey'
+      const callback = jest.fn()
+
+      redisClient.subscribe = jest.fn((_, cb) => cb(null))
+
+      const result = await wrapper['_subscribe'](key, callback)
+
+      expect(result).toBe(true)
+    })
+  })
+
+  describe('_unsubscribe', () => {
+    it('should unsubscribe from a Redis channel', async () => {
+      const key = 'testKey'
+      const callback = jest.fn()
+
+      redisClient.unsubscribe = jest.fn((_, cb) => cb(null))
+
+      const result = await wrapper['_unsubscribe'](key, callback)
+
+      expect(result).toBe(true)
+    })
+  })
+
+  describe('_messageReceived', () => {
+    it('should emit an event with parsed data', () => {
+      const channel = 'testChannel'
+      const data = 'testData'
+      const parsedData = JSON.stringify(data)
+
+      const emitter = new EventEmitter()
+      wrapper['_emitter'] = emitter
+
+      const emitSpy = jest.spyOn(emitter, 'emit')
+
+      wrapper['_messageReceived'](channel, parsedData)
+
+      expect(emitSpy).toHaveBeenCalledWith(channel, data)
+    })
+  })
+
+  describe('_getLock', () => {
+    it('should acquire a lock in Redis', async () => {
+      const key = 'testKey'
+
+      redisClient.set = jest.fn((_, __, ___, ____, cb) => cb(null, 'OK'))
+
+      const result = await wrapper['_getLock'](key)
+
+      expect(result).toBe(true)
+    })
+  })
+
+  describe('_getNotifKey', () => {
+    it('should return the notification key', () => {
+      const key = 'testKey'
+      const expectedNotifKey = `${wrapper['_config'].keyPrefix}${wrapper['_config'].keySeperator}${wrapper['_config'].notifPrefix}${wrapper['_config'].keySeperator}${key}`
+
+      const result = wrapper['_getNotifKey'](key)
+
+      expect(result).toBe(expectedNotifKey)
+    })
+  })
+
+  describe('_getLockKey', () => {
+    it('should return the lock key', () => {
+      const key = 'testKey'
+      const expectedLockKey = `${wrapper['_config'].keyPrefix}${wrapper['_config'].keySeperator}${wrapper['_config'].lockPrefix}${wrapper['_config'].keySeperator}${key}`
+
+      const result = wrapper['_getLockKey'](key)
+
+      expect(result).toBe(expectedLockKey)
+    })
+  })
+
+  describe('_getDataKey', () => {
+    it('should return the data key', () => {
+      const key = 'testKey'
+      const expectedDataKey = `${wrapper['_config'].keyPrefix}${wrapper['_config'].keySeperator}${key}`
+
+      const result = wrapper['_getDataKey'](key)
+
+      expect(result).toBe(expectedDataKey)
+    })
+  })
+})


### PR DESCRIPTION
Add tests for `DistributedPromiseWrapper` class and set up CI workflow.

* **Tests for `DistributedPromiseWrapper` class**
  - Add imports for `DistributedPromiseWrapper`, `RedisClient`, and `EventEmitter`.
  - Add a mock implementation for the Redis client.
  - Add tests for the `wrap` method, covering cache hits, cache misses, and lock acquisition.
  - Add tests for the `_get`, `_pushData`, `_subscribe`, `_unsubscribe`, `_messageReceived`, `_getLock`, `_getNotifKey`, `_getLockKey`, and `_getDataKey` methods.

* **CI Workflow**
  - Add a GitHub Actions workflow file for continuous integration.
  - Configure the workflow to run tests on push and pull request events.
  - Set up the workflow to use Node.js and install dependencies.
  - Add a step to run the tests using the `npm test` command.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jpwilliams/distributed-promise/pull/183?shareId=1da551cd-0055-4c22-8af5-31e8dd05f872).